### PR TITLE
Fix VSCode saving issue

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,10 @@
   },
   "[mdx]": {
     "editor.formatOnSave": false,
-    "editor.defaultFormatter": "unifiedjs.vscode-mdx"
+    "editor.defaultFormatter": "unifiedjs.vscode-mdx",
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "never"
+    }
   },
   "files.exclude": {
     "**/content/blog/**/*.mdx": false


### PR DESCRIPTION
### TL;DR

Disabled automatic import organization on save for MDX files in VS Code.

Fix - https://github.com/mdx-js/mdx-analyzer/issues/502

### What changed?

Added a configuration to the VS Code settings for MDX files that explicitly sets `"source.organizeImports": "never"` in the `editor.codeActionsOnSave` section. This prevents VS Code from automatically organizing imports when saving MDX files.

### How to test?

1. Open an MDX file in VS Code
2. Add or modify imports in an unorganized manner
3. Save the file
4. Verify that the imports remain in their original order and are not automatically organized

### Why make this change?

Automatic import organization in MDX files can sometimes cause issues with the specific order of imports needed for proper MDX rendering. This change ensures that developers maintain full control over the import order in MDX files, preventing potential rendering problems caused by automatic reorganization.